### PR TITLE
The version of dependent Mongoid can be upgraded without changes to the main code

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,7 +4,7 @@ source "http://rubygems.org"
 gemspec
 
 group :development do
-  gem "rails", "3.0.0"
+  gem "rails", "~> 3.1.3"
 end
 
 group :test do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -2,9 +2,9 @@ require 'rails'
 require 'mongoid'
 require 'will_paginate'
 require 'will_paginate_mongoid'
-
 require File.join(File.dirname(__FILE__), 'fake_app')
 require 'rspec/rails'
+
 
 Dir["#{File.dirname(__FILE__)}/support/**/*.rb"].each {|f| require f}
 
@@ -18,5 +18,5 @@ RSpec.configure do |config|
 end
 
 Mongoid.configure do |config|
-  config.master = Mongo::Connection.new.db("will_paginate_mongoid")
+  config.master = Mongo::Connection.new.db("will_paginate_mongoid_test")
 end

--- a/will_paginate_mongoid.gemspec
+++ b/will_paginate_mongoid.gemspec
@@ -18,6 +18,7 @@ Gem::Specification.new do |s|
   s.executables   = `git ls-files -- bin/*`.split("\n").map{ |f| File.basename(f) }
   s.require_paths = ["lib"]
 
-  s.add_runtime_dependency "mongoid", "~> 2.2.2"
+  s.add_runtime_dependency "mongoid", "~> 2.4"
+  s.add_runtime_dependency "bson_ext", "~> 1.5"
   s.add_runtime_dependency "will_paginate", "~> 3.0.2"
 end


### PR DESCRIPTION
which makes it possible to use newer versions of Rails and Mongoid with this gem.

Tests passed.
