### PR TITLE
Convert options[:per_page] to integer

### DIFF
--- a/lib/will_paginate_mongoid/mongoid_paginator.rb
+++ b/lib/will_paginate_mongoid/mongoid_paginator.rb
@@ -18,7 +18,7 @@ module WillPaginateMongoid
       def self.base_options(options)
         options[:page] ||= 1
         options[:per_page] ||= 10
-        options[:offset] = (options[:page].to_i - 1) * options[:per_page]
+        options[:offset] = (options[:page].to_i - 1) * options[:per_page].to_i
         options
       end
 


### PR DESCRIPTION
GSL is monkeypatching Fixnum and causing an exception here.

That's the offending line in GSL but I think paginate has to be fixed anyways.
https://github.com/romanbsd/rb-gsl/blob/master/lib/gsl/oper.rb#L15
