### PR TITLE
Supporting Mongoid 8.x / WillPaginate 4.0.0

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,11 +4,10 @@ source "http://rubygems.org"
 gemspec
 
 group :development do
-  gem "rails", "~> 3.1.3"
-  gem "bson_ext", "~> 1.5", :platforms => :ruby
+  gem "rails", "~> 7.1.0"
 end
 
 group :test do
-  gem "rspec", "2.7.0"
-  gem "rspec-rails", "2.7.0"
+  gem "rspec-its", "1.3.0"
+  gem "rspec-rails", "4.0.2"
 end

--- a/spec/integration/mongoid_paginator_spec.rb
+++ b/spec/integration/mongoid_paginator_spec.rb
@@ -6,6 +6,7 @@ describe WillPaginateMongoid::MongoidPaginator do
       include ::Mongoid::Document
       field :title, :type => String
     end
+    WillPaginate.per_page = 10
   end
   
   describe :paginate do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -4,19 +4,19 @@ require 'will_paginate'
 require 'will_paginate_mongoid'
 require File.join(File.dirname(__FILE__), 'fake_app')
 require 'rspec/rails'
-
+require 'rspec/its'
 
 Dir["#{File.dirname(__FILE__)}/support/**/*.rb"].each {|f| require f}
 
 RSpec.configure do |config|
   config.mock_with :rspec
   config.before :each do
-    Mongoid.master.collections.select do |collection|
+    Mongoid::Clients.default.collections.select do |collection|
       collection.name !~ /system/
     end.each(&:drop)
   end
 end
 
 Mongoid.configure do |config|
-  config.master = Mongo::Connection.new.db("will_paginate_mongoid_test")
+  config.connect_to("will_paginate_mongoid_test")
 end

--- a/will_paginate_mongoid.gemspec
+++ b/will_paginate_mongoid.gemspec
@@ -19,6 +19,6 @@ Gem::Specification.new do |s|
   s.executables   = `git ls-files -- bin/*`.split("\n").map{ |f| File.basename(f) }
   s.require_paths = ["lib"]
 
-  s.add_runtime_dependency "mongoid"
-  s.add_runtime_dependency "will_paginate", "~> 3.0"
+  s.add_runtime_dependency "mongoid", "< 9.0"
+  s.add_runtime_dependency "will_paginate", "~> 4.0"
 end


### PR DESCRIPTION
I was looking to upgrade WillPaginate to 4.0.0 (we are using Mongoid 8.x) and it appears that [will_paginate_mongoid](https://github.com/lucasas/will_paginate_mongoid) is holding back that upgrade. I've just created a branch and got the specs running again as this seems like it was created some time ago now.